### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ,
+ignore-words-list = nd,
 skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+# Source: https://github.com/per1234/.github/blob/main/workflow-templates/spell-check.md
+name: Spell Check
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Arduino_ScienceKitCarrier
 =========================
 [![Check Arduino](https://github.com/arduino-libraries/Arduino_ScienceKitCarrier/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_ScienceKitCarrier/actions/workflows/check-arduino.yml)
+[![Spell Check](https://github.com/arduino-libraries/Arduino_ScienceKitCarrier/workflows/Spell%20Check/badge.svg)](https://github.com/arduino-libraries/Arduino_ScienceKitCarrier/actions?workflow=Spell+Check)
 
 Library to use the Science Kit Carrier rev3 sensors and make possible the connection with Arduino Science Journal App
 

--- a/extras/functions_generator_firmware/SKr3_waves/led_gauge.h
+++ b/extras/functions_generator_firmware/SKr3_waves/led_gauge.h
@@ -48,7 +48,7 @@ class LedGauge: public LedArray{
       two=_two;
     }
 
-    //Call it everytime you want to read the pot and update leds
+    //Call it every time you want to read the pot and update leds
     void refresh(){
       value=analogRead(pot);
       if (value<=ADC_RES+100){  // pots create strange effects near 0

--- a/src/Arduino_ScienceKitCarrier.h
+++ b/src/Arduino_ScienceKitCarrier.h
@@ -32,7 +32,7 @@
 #include "Arduino_GroveI2C_Ultrasonic.h"
 #include <PDM.h>
 
-#include "../../OneWireNg/src/platform/OneWireNg_PicoRP2040.h"  // forces to use gpio insted PIO hw
+#include "../../OneWireNg/src/platform/OneWireNg_PicoRP2040.h"  // forces to use gpio instead PIO hw
 #define OneWireNg_CurrentPlatform OneWireNg_PicoRP2040
 #include "drivers/DSTherm.h"
 #include "utils/Placeholder.h"

--- a/src/utils/Arduino_ScienceKitCarrier_definitions.h
+++ b/src/utils/Arduino_ScienceKitCarrier_definitions.h
@@ -35,7 +35,7 @@
 const uint32_t SHUNT_MICRO_OHM{100000};    // check schematic R20
 const uint16_t MAXIMUM_AMPS{1};            // 1A
 
-// Resistence
+// Resistance
 #define RESISTANCE_PIN A2
 #define RESISTOR_AUX  1000.0
 #define REF_VOLTAGE 3.3


### PR DESCRIPTION
On every push, pull request, and periodically, use codespell to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the field of . Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.