### PR TITLE
Avoid assumption of relative location of dependency installation

### DIFF
--- a/src/Arduino_ScienceKitCarrier.h
+++ b/src/Arduino_ScienceKitCarrier.h
@@ -43,7 +43,8 @@
 #include "Arduino_BMI270_BMM150.h"
 
 #ifdef ARDUINO_NANO_RP2040_CONNECT
-#include "../../OneWireNg/src/platform/OneWireNg_PicoRP2040.h"  // forces to use gpio instead PIO hw
+#include <OneWireNg.h>
+#include <platform/OneWireNg_PicoRP2040.h>  // forces to use gpio instead PIO hw
 #define OneWireNg_CurrentPlatform OneWireNg_PicoRP2040
 #endif
 #ifdef ARDUINO_NANO_ESP32


### PR DESCRIPTION
The library has a dependency on the "OneWireNg" library. Previously, a relative path was specified in the `#include` directive for a header file from that library. This introduced a reliance on the dependency being installed in a specific path relative to the Arduino_ScienceKitCarrier library. That assumption holds true in the case where the dependency was installed via the Arduino IDE or Arduino CLI Library Manager and is used in situ. However, it falls apart in other use cases.

The most significant of these alternative use cases is Arduino Cloud Editor. There are several deviations in the locations of library installations on the Arduino Cloud server:

* In order to support the coexistence of multiple versions, Library Manager libraries are installed under a folder that includes a revision identifier in addition to the library name (e.g., `OneWireNg_0.14.1_37fe3dc3c2e551b0`).
* Library installations may be located under different general parent paths (e.g., `/var/run/arduino/directories-user/libraries` vs. `/run/arduino/directories-data/internal`).

In these environments, compilation of the library for the Nano RP2040 Connect board (the problematic `#include` directive is inside a conditional block specific to that board) failed:

```
/var/run/arduino/directories-user/libraries/Arduino_ScienceKitCarrier/src/Arduino_ScienceKitCarrier.h:46:10: fatal error: ../../OneWireNg/src/platform/OneWireNg_PicoRP2040.h: No such file or directory
#include "../../OneWireNg/src/platform/OneWireNg_PicoRP2040.h"  // forces to use gpio instead PIO hw
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The solution is to avoid any assumption of the relative location of the referenced header file, and instead utilize the standard "library discovery" feature of the sketch build system. Library discovery is only performed for header files present in the root of the target library's source code folder. The target header file is located under a subfolder. For this reason, it was necessary to add an `#include` directive for a different header file from the "OneWireNg" library in order to achieve discovery. That discovery causes the path of the library to be added to the compiler search path, and thus obviates the need for discovery for the subsequent `#include` targeting the header file in the subfolder. The added `#include` directive is otherwise technically insignificant because it was already transitively `#include`d via the target header file.

---

Originally reported at https://forum.arduino.cc/t/error-reflashing-r3-arduino-board-for-science-kit/1437758